### PR TITLE
Convert pressure value from pascal to hectopascal

### DIFF
--- a/src/bsecsensor.h
+++ b/src/bsecsensor.h
@@ -155,7 +155,7 @@ class BSECSensor : public Component {
                 switch (sensorPushNum++) {
                     case 1: temperature->publish_state(iaqSensor.temperature); break;
                     case 2: humidity->publish_state(iaqSensor.humidity); break;
-                    case 3: pressure->publish_state(iaqSensor.pressure); break;
+                    case 3: pressure->publish_state(iaqSensor.pressure/100.0); break;
                     case 4: gasResistance->publish_state(iaqSensor.gasResistance); break;
                     case 5: staticIaq->publish_state(iaqSensor.staticIaq); break;
                     case 6: staticIaqAccuracy->publish_state(iaqSensor.staticIaqAccuracy); break;


### PR DESCRIPTION
Thank you for publishing this component, it was exactly what I was looking for  👍 

I noticed, that the unit for the air pressure is not right, the number was too high by the factor 100. I think it's better to publish the pressure in hPa already in the BSECSensor class instead of just changing the unit form hPa to Pa in the yaml.