### PR TITLE
Make git ignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+__pycache__


### PR DESCRIPTION
Sometimes when compiling esphome nodes that use this library, a `__pycache__` directory is created (if `esphome-bsec-bme680` is used as a git submodule), which causes `git` to suggest that there's untracked content.

There's no point on these files being committed, so adding `__pycache__` to `.gitignore`.