### PR TITLE
Tidy state push yields and also during load/save

### DIFF
--- a/bme680_bsec/bme680_bsec.cpp
+++ b/bme680_bsec/bme680_bsec.cpp
@@ -74,39 +74,16 @@ float BME680BSECComponent::get_setup_priority() const { return setup_priority::D
 
 void BME680BSECComponent::loop() {
   if (this->check_bsec_status_() && this->bsec_.run()) {
-    this->sensor_push_num_ = 1;
+    yield();
     this->save_state_();
-  }
-
-  // In order not to block here, spread the sensor state pushes
-  // across subsequent calls otherwise we end up with API disconnects
-  if (this->sensor_push_num_ > 0 && this->sensor_push_num_ <= 8) {
-    switch (this->sensor_push_num_++) {
-      case 1:
-        this->publish_state_(this->temperature_sensor_, this->bsec_.temperature);
-        break;
-      case 2:
-        this->publish_state_(this->humidity_sensor_, this->bsec_.humidity);
-        break;
-      case 3:
-        this->publish_state_(this->pressure_sensor_, this->bsec_.pressure / 100.0);
-        break;
-      case 4:
-        this->publish_state_(this->gas_resistance_sensor_, this->bsec_.gasResistance);
-        break;
-      case 5:
-        this->publish_state_(this->iaq_sensor_, this->get_iaq_());
-        break;
-      case 6:
-        this->publish_state_(this->iaq_accuracy_sensor_, IAQ_ACCURACY_STATES[this->get_iaq_accuracy_()]);
-        break;
-      case 7:
-        this->publish_state_(this->co2_equivalent_sensor_, this->bsec_.co2Equivalent);
-        break;
-      case 8:
-        this->publish_state_(this->breath_voc_equivalent_sensor_, this->bsec_.breathVocEquivalent);
-        break;
-    }
+    this->publish_state_(this->temperature_sensor_, this->bsec_.temperature);
+    this->publish_state_(this->humidity_sensor_, this->bsec_.humidity);
+    this->publish_state_(this->pressure_sensor_, this->bsec_.pressure / 100.0);
+    this->publish_state_(this->gas_resistance_sensor_, this->bsec_.gasResistance);
+    this->publish_state_(this->iaq_sensor_, this->get_iaq_());
+    this->publish_state_(this->iaq_accuracy_sensor_, IAQ_ACCURACY_STATES[this->get_iaq_accuracy_()]);
+    this->publish_state_(this->co2_equivalent_sensor_, this->bsec_.co2Equivalent);
+    this->publish_state_(this->breath_voc_equivalent_sensor_, this->bsec_.breathVocEquivalent);
   }
 }
 
@@ -115,6 +92,7 @@ void BME680BSECComponent::publish_state_(sensor::Sensor *sensor, float value) {
     return;
   }
   sensor->publish_state(value);
+  yield();
 }
 
 void BME680BSECComponent::publish_state_(text_sensor::TextSensor *sensor, std::string value) {
@@ -122,6 +100,7 @@ void BME680BSECComponent::publish_state_(text_sensor::TextSensor *sensor, std::s
     return;
   }
   sensor->publish_state(value);
+  yield();
 }
 
 void BME680BSECComponent::set_temperature_offset(float offset) {
@@ -187,8 +166,10 @@ void BME680BSECComponent::load_state_() {
 
   uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
   if (this->bsec_state_.load(&state)) {
+    yield();
     ESP_LOGI(TAG, "Loading state");
     this->bsec_.setState(state);
+    yield();
     this->check_bsec_status_();
   }
 }
@@ -201,6 +182,7 @@ void BME680BSECComponent::save_state_() {
 
   uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
   this->bsec_.getState(state);
+  yield();
   if (!this->check_bsec_status_()) {
     return;
   }
@@ -208,6 +190,7 @@ void BME680BSECComponent::save_state_() {
   ESP_LOGI(TAG, "Saving state");
   this->bsec_state_.save(&state);
   last_millis = millis();
+  yield();
 }
 
 }  // namespace bme680_bsec

--- a/bme680_bsec/bme680_bsec.h
+++ b/bme680_bsec/bme680_bsec.h
@@ -66,7 +66,6 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   ESPPreferenceObject bsec_state_;
   uint32_t state_save_interval_{21600000};  // 6 hours - 4 times a day
   BME680BSECIAQMode iaq_mode_{BME680_IAQ_MODE_STATIC};
-  uint8_t sensor_push_num_{0};
 
   sensor::Sensor *temperature_sensor_;
   sensor::Sensor *pressure_sensor_;


### PR DESCRIPTION
Instead of rolling our own yielding mechanism for the sensor state
pushes make use of the standard call!

Also adds yields during BSEC state load/save operations.