### PR TITLE
Remove usage of Bsec helper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,26 +116,6 @@ text_sensor:
       name: "BME680 IAQ Accuracy"
 ```
 
-## Multiple sensors
-By defining multiple platform instances it is possible to read from multiple sensors.
-```yaml
-bme680_bsec:
-  - id: bme680_one
-    address: 0x76
-  - id: bme680_two
-    address: 0x77
-
-sensor:
-  - platform: bme680_bsec
-    bme680_bsec_id: bme680_one
-    temperature:
-      name: "BME680 One Temperature"
-  - platform: bme680_bsec
-    bme680_bsec_id: bme680_two
-    temperature:
-      name: "BME680 Two Temperature"
-```
-
 ## Indoor Air Quality (IAQ) Measurement
 Indoor Air Quality measurements are expressed in the IAQ index scale with 25IAQ corresponding to typical good air and 250IAQ
 indicating typical polluted air after calibration.

--- a/bme680_bsec/__init__.py
+++ b/bme680_bsec/__init__.py
@@ -6,7 +6,6 @@ from esphome.const import CONF_ID
 CODEOWNERS = ['@trvrnrth']
 DEPENDENCIES = ['i2c']
 AUTO_LOAD = ['sensor', 'text_sensor']
-MULTI_CONF = True
 
 CONF_BME680_BSEC_ID = 'bme680_bsec_id'
 CONF_TEMPERATURE_OFFSET = 'temperature_offset'

--- a/bme680_bsec/bme680_bsec.cpp
+++ b/bme680_bsec/bme680_bsec.cpp
@@ -12,64 +12,126 @@ static const char *TAG = "bme680_bsec.sensor";
 
 static const std::string IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
 
-std::map<uint8_t, BME680BSECComponent *> BME680BSECComponent::instances;
+BME680BSECComponent * BME680BSECComponent::instance;
 
 void BME680BSECComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up BME680 via BSEC...");
-  BME680BSECComponent::instances[this->address_] = this;
-  this->bsec_.begin(this->address_, BME680_I2C_INTF, BME680BSECComponent::read_bytes_wrapper,
-                    BME680BSECComponent::write_bytes_wrapper, Bsec::delay_ms);
+  BME680BSECComponent::instance = this;
 
-  if (!this->check_bsec_status_()) {
+  this->bsec_status_ = bsec_init();
+  if (this->bsec_status_ != BSEC_OK) {
     this->mark_failed();
     return;
   }
 
-  float bsec_sample_rate;
+  this->bme680_.dev_id = this->address_;
+  this->bme680_.intf = BME680_I2C_INTF;
+  this->bme680_.read = BME680BSECComponent::read_bytes_wrapper;
+  this->bme680_.write = BME680BSECComponent::write_bytes_wrapper;
+  this->bme680_.delay_ms = BME680BSECComponent::delay_ms;
+  this->bme680_.amb_temp = 25;
+  this->bme680_.power_mode = BME680_FORCED_MODE;
+
+  this->bme680_status_ = bme680_init(&this->bme680_);
+  if (this->bme680_status_ != BME680_OK) {
+    this->mark_failed();
+    return;
+  }
+
   if (this->sample_rate_ == SAMPLE_RATE_ULP) {
     const uint8_t bsec_config[] = {
-      #include "config/generic_33v_300s_28d/bsec_iaq.txt"
+#include "config/generic_33v_300s_28d/bsec_iaq.txt"
     };
-    this->bsec_.setConfig(bsec_config);
-    bsec_sample_rate = BSEC_SAMPLE_RATE_ULP;
+    this->set_config_(bsec_config);
+    this->update_subscription_(BSEC_SAMPLE_RATE_ULP);
   } else {
     const uint8_t bsec_config[] = {
-      #include "config/generic_33v_3s_28d/bsec_iaq.txt"
+#include "config/generic_33v_3s_28d/bsec_iaq.txt"
     };
-    this->bsec_.setConfig(bsec_config);
-    bsec_sample_rate = BSEC_SAMPLE_RATE_LP;
+    this->set_config_(bsec_config);
+    this->update_subscription_(BSEC_SAMPLE_RATE_LP);
+  }
+  if (this->bsec_status_ != BSEC_OK) {
+    this->mark_failed();
+    return;
   }
 
   this->load_state_();
+}
 
-  // Subscribe to sensor values
-  bsec_virtual_sensor_t sensor_list[7] = {
-      BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE,
-      BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY,
-      BSEC_OUTPUT_RAW_PRESSURE,
-      BSEC_OUTPUT_RAW_GAS,
-      this->iaq_mode_ == IAQ_MODE_STATIC ? BSEC_OUTPUT_STATIC_IAQ : BSEC_OUTPUT_IAQ,
-      BSEC_OUTPUT_CO2_EQUIVALENT,
-      BSEC_OUTPUT_BREATH_VOC_EQUIVALENT,
-  };
-  this->bsec_.updateSubscription(sensor_list, 7, bsec_sample_rate);
+void BME680BSECComponent::set_config_(const uint8_t *config) {
+  uint8_t work_buffer[BSEC_MAX_WORKBUFFER_SIZE];
+  this->bsec_status_ = bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, work_buffer, sizeof(work_buffer));
+}
+
+void BME680BSECComponent::update_subscription_(float sample_rate) {
+  bsec_sensor_configuration_t virtual_sensors[BSEC_NUMBER_OUTPUTS];
+  int num_virtual_sensors = 0;
+
+  if (this->iaq_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = this->iaq_mode_ == IAQ_MODE_STATIC ? BSEC_OUTPUT_STATIC_IAQ : BSEC_OUTPUT_IAQ;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->co2_equivalent_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_CO2_EQUIVALENT;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->breath_voc_equivalent_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_BREATH_VOC_EQUIVALENT;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->pressure_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_PRESSURE;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->gas_resistance_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_GAS;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->temperature_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  if (this->humidity_sensor_) {
+    virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY;
+    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    num_virtual_sensors++;
+  }
+
+  bsec_sensor_configuration_t sensor_settings[BSEC_MAX_PHYSICAL_SENSOR];
+  uint8_t num_sensor_settings = BSEC_MAX_PHYSICAL_SENSOR;
+  this->bsec_status_ = bsec_update_subscription(virtual_sensors, num_virtual_sensors, sensor_settings, &num_sensor_settings);
 }
 
 void BME680BSECComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "BME680 via BSEC:");
-  ESP_LOGCONFIG(TAG, "  BSEC Version: %d.%d.%d.%d", this->bsec_.version.major, this->bsec_.version.minor,
-                this->bsec_.version.major_bugfix, this->bsec_.version.minor_bugfix);
+
+  bsec_version_t version;
+  bsec_get_version(&version);
+  ESP_LOGCONFIG(TAG, "  BSEC Version: %d.%d.%d.%d", version.major, version.minor, version.major_bugfix, version.minor_bugfix);
+  
   LOG_I2C_DEVICE(this);
 
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Communication failed with BSEC Status: %d, BME680 Status: %d", this->last_bsec_status_,
-             this->last_bme680_status_);
+    ESP_LOGE(TAG, "Communication failed (BSEC Status: %d, BME680 Status: %d)", this->bsec_status_, this->bme680_status_);
   }
 
   ESP_LOGCONFIG(TAG, "  Temperature Offset: %.2f", this->temperature_offset_);
   ESP_LOGCONFIG(TAG, "  IAQ Mode: %s", this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile");
   ESP_LOGCONFIG(TAG, "  Sample Rate: %s", this->sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
-  ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_);
+  ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_ms_);
 
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
@@ -85,94 +147,201 @@ void BME680BSECComponent::dump_config() {
 float BME680BSECComponent::get_setup_priority() const { return setup_priority::DATA; }
 
 void BME680BSECComponent::loop() {
-  if (this->check_bsec_status_() && this->bsec_.run()) {
-    yield();
-    this->save_state_();
-    this->publish_state_(this->temperature_sensor_, this->bsec_.temperature);
-    this->publish_state_(this->humidity_sensor_, this->bsec_.humidity);
-    this->publish_state_(this->pressure_sensor_, this->bsec_.pressure / 100.0);
-    this->publish_state_(this->gas_resistance_sensor_, this->bsec_.gasResistance);
-    this->publish_state_(this->iaq_sensor_, this->get_iaq_());
-    this->publish_state_(this->iaq_accuracy_text_sensor_, IAQ_ACCURACY_STATES[this->get_iaq_accuracy_()]);
-    this->publish_state_(this->iaq_accuracy_sensor_, this->get_iaq_accuracy_(), true);
-    this->publish_state_(this->co2_equivalent_sensor_, this->bsec_.co2Equivalent);
-    this->publish_state_(this->breath_voc_equivalent_sensor_, this->bsec_.breathVocEquivalent);
+  this->run_();
+
+  if (this->bsec_status_ < BSEC_OK || this->bme680_status_ < BME680_OK) {
+    this->status_set_error();
+  } else {
+    this->status_clear_error();
+  }
+  if (this->bsec_status_ > BSEC_OK || this->bme680_status_ > BME680_OK) {
+    this->status_set_warning();
+  } else {
+    this->status_clear_warning();
   }
 }
 
-void BME680BSECComponent::publish_state_(sensor::Sensor *sensor, float value, bool change_only) {
+void BME680BSECComponent::run_() {
+  int64_t curr_time_ns = this->get_time_ns_();
+  if (curr_time_ns < this->next_call_ns_) {
+    return;
+  }
+
+  ESP_LOGV(TAG, "Performing sensor run");
+
+  bsec_bme_settings_t bme680_settings;
+  this->bsec_status_ = bsec_sensor_control(curr_time_ns, &bme680_settings);
+  if (this->bsec_status_ < BSEC_OK) {
+    ESP_LOGW(TAG, "Failed to fetch sensor control settings (BSEC Error Code %d)", this->bsec_status_);
+    return;
+  }
+  this->next_call_ns_ = bme680_settings.next_call;
+
+  this->bme680_.gas_sett.run_gas = bme680_settings.run_gas;
+  this->bme680_.tph_sett.os_hum = bme680_settings.humidity_oversampling;
+  this->bme680_.tph_sett.os_temp = bme680_settings.temperature_oversampling;
+  this->bme680_.tph_sett.os_pres = bme680_settings.pressure_oversampling;
+  this->bme680_.gas_sett.heatr_temp = bme680_settings.heater_temperature;
+  this->bme680_.gas_sett.heatr_dur = bme680_settings.heating_duration;
+  uint16_t desired_settings = BME680_OST_SEL | BME680_OSP_SEL | BME680_OSH_SEL | BME680_FILTER_SEL | BME680_GAS_SENSOR_SEL;
+  this->bme680_status_ = bme680_set_sensor_settings(desired_settings, &this->bme680_);
+  if (this->bme680_status_ != BME680_OK) {
+    ESP_LOGW(TAG, "Failed to set sensor settings (BME680 Error Code %d)", this->bme680_status_);
+    return;
+  }
+
+  this->bme680_status_ = bme680_set_sensor_mode(&this->bme680_);
+  if (this->bme680_status_ != BME680_OK) {
+    ESP_LOGW(TAG, "Failed to set sensor mode (BME680 Error Code %d)", this->bme680_status_);
+    return;
+  }
+
+  uint16_t meas_dur = 0;
+  bme680_get_profile_dur(&meas_dur, &this->bme680_);
+  ESP_LOGV(TAG, "Queueing read in %ums", meas_dur);
+  this->set_timeout("read", meas_dur, [this, bme680_settings]() { this->read_(bme680_settings); });
+}
+
+void BME680BSECComponent::read_(bsec_bme_settings_t bme680_settings) {
+  ESP_LOGV(TAG, "Reading data");
+  struct bme680_field_data data;
+  this->bme680_status_ = bme680_get_sensor_data(&data, &this->bme680_);
+
+  if (this->bme680_status_ != BME680_OK) {
+    ESP_LOGW(TAG, "Failed to get sensor data (BME680 Error Code %d)", this->bme680_status_);
+    return;
+  }
+  if (!(data.status & BME680_NEW_DATA_MSK)) {
+    ESP_LOGD(TAG, "BME680 did not report new data");
+    return;
+  }
+
+  bsec_input_t inputs[BSEC_MAX_PHYSICAL_SENSOR]; // Temperature, Pressure, Humidity & Gas Resistance
+  uint8_t num_inputs = 0;
+  int64_t curr_time_ns = this->get_time_ns_();
+
+  if (bme680_settings.process_data & BSEC_PROCESS_TEMPERATURE) {
+    inputs[num_inputs].sensor_id = BSEC_INPUT_TEMPERATURE;
+    inputs[num_inputs].signal = data.temperature / 100.0f;
+    inputs[num_inputs].time_stamp = curr_time_ns;
+    num_inputs++;
+
+    // Temperature offset from the real temperature due to external heat sources
+    inputs[num_inputs].sensor_id = BSEC_INPUT_HEATSOURCE;
+    inputs[num_inputs].signal = this->temperature_offset_;
+    inputs[num_inputs].time_stamp = curr_time_ns;
+    num_inputs++;
+  }
+  if (bme680_settings.process_data & BSEC_PROCESS_HUMIDITY) {
+    inputs[num_inputs].sensor_id = BSEC_INPUT_HUMIDITY;
+    inputs[num_inputs].signal = data.humidity / 1000.0f;
+    inputs[num_inputs].time_stamp = curr_time_ns;
+    num_inputs++;
+  }
+  if (bme680_settings.process_data & BSEC_PROCESS_PRESSURE) {
+    inputs[num_inputs].sensor_id = BSEC_INPUT_PRESSURE;
+    inputs[num_inputs].signal = data.pressure;
+    inputs[num_inputs].time_stamp = curr_time_ns;
+    num_inputs++;
+  }
+  if (bme680_settings.process_data & BSEC_PROCESS_GAS) {
+    inputs[num_inputs].sensor_id = BSEC_INPUT_GASRESISTOR;
+    inputs[num_inputs].signal = data.gas_resistance;
+    inputs[num_inputs].time_stamp = curr_time_ns;
+    num_inputs++;
+  }
+  if (num_inputs < 1) {
+    ESP_LOGD(TAG, "No signal inputs available for BSEC");
+    return;
+  }
+
+  bsec_output_t outputs[BSEC_NUMBER_OUTPUTS];
+  uint8_t num_outputs = BSEC_NUMBER_OUTPUTS;
+  this->bsec_status_ = bsec_do_steps(inputs, num_inputs, outputs, &num_outputs);
+  if (this->bsec_status_ != BSEC_OK) {
+    ESP_LOGW(TAG, "BSEC failed to process signals (BSEC Error Code %d)", this->bsec_status_);
+    return;
+  }
+  if (num_outputs < 1) {
+    ESP_LOGD(TAG, "No signal outputs provided by BSEC");
+    return;
+  }
+
+  this->publish_(outputs, num_outputs);
+}
+
+void BME680BSECComponent::publish_(const bsec_output_t * outputs, uint8_t num_outputs) {
+  ESP_LOGV(TAG, "Publishing sensor states");
+  for (uint8_t i = 0; i < num_outputs; i++) {
+    switch (outputs[i].sensor_id) {
+      case BSEC_OUTPUT_IAQ:
+      case BSEC_OUTPUT_STATIC_IAQ:
+        uint8_t accuracy;
+        accuracy = outputs[i].accuracy;
+        this->publish_sensor_state_(this->iaq_sensor_, outputs[i].signal);
+        this->publish_sensor_state_(this->iaq_accuracy_text_sensor_, IAQ_ACCURACY_STATES[accuracy]);
+        this->publish_sensor_state_(this->iaq_accuracy_sensor_, accuracy, true);
+
+        // Queue up an opportunity to save state
+        this->defer("save_state", [this, accuracy]() { this->save_state_(accuracy); });
+        break;
+      case BSEC_OUTPUT_CO2_EQUIVALENT:
+        this->publish_sensor_state_(this->co2_equivalent_sensor_, outputs[i].signal);
+        break;
+      case BSEC_OUTPUT_BREATH_VOC_EQUIVALENT:
+        this->publish_sensor_state_(this->breath_voc_equivalent_sensor_, outputs[i].signal);
+        break;
+      case BSEC_OUTPUT_RAW_PRESSURE:
+        this->publish_sensor_state_(this->pressure_sensor_, outputs[i].signal / 100.0f);
+        break;
+      case BSEC_OUTPUT_RAW_GAS:
+        this->publish_sensor_state_(this->gas_resistance_sensor_, outputs[i].signal);
+        break;
+      case BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE:
+        this->publish_sensor_state_(this->temperature_sensor_, outputs[i].signal);
+        break;
+      case BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY:
+        this->publish_sensor_state_(this->humidity_sensor_, outputs[i].signal);
+        break;
+    }
+  }
+}
+
+int64_t BME680BSECComponent::get_time_ns_() {
+  int64_t time_ms = millis();
+  if (this->last_time_ms_ > time_ms) {
+    this->millis_overflow_counter_++;
+  }
+  this->last_time_ms_ = time_ms;
+
+  return (time_ms + ((int64_t)this->millis_overflow_counter_ << 32)) * INT64_C(1000000);
+}
+
+void BME680BSECComponent::publish_sensor_state_(sensor::Sensor *sensor, float value, bool change_only) {
   if (!sensor || (change_only && sensor->has_state() && sensor->state == value)) {
     return;
   }
   sensor->publish_state(value);
-  yield();
 }
 
-void BME680BSECComponent::publish_state_(text_sensor::TextSensor *sensor, std::string value) {
+void BME680BSECComponent::publish_sensor_state_(text_sensor::TextSensor *sensor, std::string value) {
   if (!sensor || (sensor->has_state() && sensor->state == value)) {
     return;
   }
   sensor->publish_state(value);
-  yield();
-}
-
-void BME680BSECComponent::set_temperature_offset(float offset) {
-  this->temperature_offset_ = offset;
-  this->bsec_.setTemperatureOffset(offset);
-}
-
-void BME680BSECComponent::set_iaq_mode(IAQMode iaq_mode) { this->iaq_mode_ = iaq_mode; }
-
-void BME680BSECComponent::set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
-
-void BME680BSECComponent::set_state_save_interval(uint32_t interval) { this->state_save_interval_ = interval; }
-
-float BME680BSECComponent::get_iaq_() {
-  return this->iaq_mode_ == IAQ_MODE_STATIC ? this->bsec_.staticIaq : this->bsec_.iaq;
-}
-
-uint8_t BME680BSECComponent::get_iaq_accuracy_() {
-  return this->iaq_mode_ == IAQ_MODE_STATIC ? this->bsec_.staticIaqAccuracy : this->bsec_.iaqAccuracy;
 }
 
 int8_t BME680BSECComponent::read_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len) {
-  return BME680BSECComponent::instances[address]->read_bytes(a_register, data, len) ? 0 : -1;
+  return BME680BSECComponent::instance->read_bytes(a_register, data, len) ? 0 : -1;
 }
 
 int8_t BME680BSECComponent::write_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len) {
-  return BME680BSECComponent::instances[address]->write_bytes(a_register, data, len) ? 0 : -1;
+  return BME680BSECComponent::instance->write_bytes(a_register, data, len) ? 0 : -1;
 }
 
-bool BME680BSECComponent::check_bsec_status_() {
-  if (this->bsec_.status != BSEC_OK && this->bsec_.status != this->last_bsec_status_) {
-    if (this->bsec_.status < BSEC_OK) {
-      ESP_LOGE(TAG, "BSEC error code: %d", this->bsec_.status);
-      this->status_set_error();
-    } else {
-      ESP_LOGW(TAG, "BSEC warning code: %d", this->bsec_.status);
-      this->status_set_warning();
-    }
-  }
-
-  if (this->bsec_.bme680Status != BME680_OK && this->bsec_.bme680Status != this->last_bme680_status_) {
-    if (this->bsec_.bme680Status < BME680_OK) {
-      ESP_LOGE(TAG, "BME680 error code: %d", this->bsec_.bme680Status);
-      this->status_set_error();
-    } else {
-      ESP_LOGW(TAG, "BME680 warning code: %d", this->bsec_.bme680Status);
-      this->status_set_warning();
-    }
-  }
-
-  this->last_bsec_status_ = this->bsec_.status;
-  this->last_bme680_status_ = this->bsec_.bme680Status;
-
-  bool ok = (this->last_bsec_status_ == BSEC_OK && this->last_bme680_status_ == BME680_OK);
-  if (ok) {
-    this->status_clear_error();
-    this->status_clear_warning();
-  }
-  return ok;
+void BME680BSECComponent::delay_ms(uint32_t period) {
+  ESP_LOGV(TAG, "Delaying for %ums", period);
+  delay(period);
 }
 
 void BME680BSECComponent::load_state_() {
@@ -181,31 +350,40 @@ void BME680BSECComponent::load_state_() {
 
   uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
   if (this->bsec_state_.load(&state)) {
-    yield();
-    ESP_LOGI(TAG, "Loading state");
-    this->bsec_.setState(state);
-    yield();
-    this->check_bsec_status_();
+    ESP_LOGV(TAG, "Loading state");
+    uint8_t work_buffer[BSEC_MAX_WORKBUFFER_SIZE];
+    this->bsec_status_ = bsec_set_state(state, BSEC_MAX_STATE_BLOB_SIZE, work_buffer, sizeof(work_buffer));
+    if (this->bsec_status_ != BSEC_OK) {
+      ESP_LOGW(TAG, "Failed to load state (BSEC Error Code %d)", this->bsec_status_);
+    }
+    ESP_LOGI(TAG, "Loaded state");
   }
 }
 
-void BME680BSECComponent::save_state_() {
-  static unsigned long last_millis = 0;
-  if (this->get_iaq_accuracy_() < 3 || (millis() - last_millis < this->state_save_interval_)) {
+void BME680BSECComponent::save_state_(uint8_t accuracy) {
+  if (accuracy < 3 || (millis() - this->last_state_save_ms_ < this->state_save_interval_ms_)) {
     return;
   }
+
+  ESP_LOGV(TAG, "Saving state");
 
   uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
-  this->bsec_.getState(state);
-  yield();
-  if (!this->check_bsec_status_()) {
+  uint8_t work_buffer[BSEC_MAX_STATE_BLOB_SIZE];
+  uint32_t num_serialized_state = BSEC_MAX_STATE_BLOB_SIZE;
+
+  this->bsec_status_ = bsec_get_state(0, state, BSEC_MAX_STATE_BLOB_SIZE, work_buffer, BSEC_MAX_STATE_BLOB_SIZE, &num_serialized_state);
+  if (this->bsec_status_ != BSEC_OK) {
+    ESP_LOGW(TAG, "Failed fetch state for save (BSEC Error Code %d)", this->bsec_status_);
     return;
   }
 
-  ESP_LOGI(TAG, "Saving state");
-  this->bsec_state_.save(&state);
-  last_millis = millis();
-  yield();
+  if (!this->bsec_state_.save(&state)) {
+    ESP_LOGW(TAG, "Failed to save state");
+    return;
+  }
+  this->last_state_save_ms_ = millis();
+
+  ESP_LOGI(TAG, "Saved state");
 }
 
 }  // namespace bme680_bsec

--- a/bme680_bsec/bme680_bsec.h
+++ b/bme680_bsec/bme680_bsec.h
@@ -59,22 +59,19 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void loop() override;
 
  protected:
+  void set_config_(const uint8_t *config);
+  void update_subscription_(float sample_rate);
+
   void run_();
   void read_(bsec_bme_settings_t bme680_settings);
   void publish_(const bsec_output_t * outputs, uint8_t num_outputs);
-
-  bool check_bsec_status_();
-
-  void load_state_();
-  void save_state_(uint8_t accuracy);
+  int64_t get_time_ns_();
 
   void publish_sensor_state_(sensor::Sensor *sensor, float value, bool change_only = false);
   void publish_sensor_state_(text_sensor::TextSensor *sensor, std::string value);
 
-  void set_config_(const uint8_t *config);
-  void update_subscription_(float sample_rate);
-  void set_state_(uint8_t *state);
-  int64_t get_time_ns_();
+  void load_state_();
+  void save_state_(uint8_t accuracy);
 
   struct bme680_dev bme680_;
   bsec_library_return_t bsec_status_{BSEC_OK};
@@ -86,7 +83,7 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
   ESPPreferenceObject bsec_state_;
   uint32_t state_save_interval_ms_{21600000};  // 6 hours - 4 times a day
-  unsigned long last_state_save_ms_ = 0;
+  uint32_t last_state_save_ms_ = 0;
 
   float temperature_offset_{0};
   IAQMode iaq_mode_{IAQ_MODE_STATIC};

--- a/bme680_bsec/bme680_bsec.h
+++ b/bme680_bsec/bme680_bsec.h
@@ -25,10 +25,10 @@ enum SampleRate {
 
 class BME680BSECComponent : public Component, public i2c::I2CDevice {
  public:
-  void set_temperature_offset(float offset);
-  void set_iaq_mode(IAQMode iaq_mode);
-  void set_sample_rate(SampleRate sample_rate);
-  void set_state_save_interval(uint32_t interval);
+  void set_temperature_offset(float offset) { this->temperature_offset_ = offset; }
+  void set_iaq_mode(IAQMode iaq_mode) { this->iaq_mode_ = iaq_mode; }
+  void set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
+  void set_state_save_interval(uint32_t interval) { this->state_save_interval_ms_ = interval; }
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
@@ -40,9 +40,7 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void set_iaq_accuracy_text_sensor(text_sensor::TextSensor *iaq_accuracy_text_sensor) {
     iaq_accuracy_text_sensor_ = iaq_accuracy_text_sensor;
   }
-  void set_iaq_accuracy_sensor(sensor::Sensor *iaq_accuracy_sensor) {
-    iaq_accuracy_sensor_ = iaq_accuracy_sensor;
-  }
+  void set_iaq_accuracy_sensor(sensor::Sensor *iaq_accuracy_sensor) { iaq_accuracy_sensor_ = iaq_accuracy_sensor; }
   void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor) {
     co2_equivalent_sensor_ = co2_equivalent_sensor;
   }
@@ -50,9 +48,10 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
     breath_voc_equivalent_sensor_ = breath_voc_equivalent_sensor;
   }
 
-  static std::map<uint8_t, BME680BSECComponent *> instances;
+  static BME680BSECComponent * instance;
   static int8_t read_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len);
   static int8_t write_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len);
+  static void delay_ms(uint32_t period);
 
   void setup() override;
   void dump_config() override;
@@ -60,20 +59,36 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void loop() override;
 
  protected:
-  bool check_bsec_status_();
-  void load_state_();
-  void save_state_();
-  float get_iaq_();
-  uint8_t get_iaq_accuracy_();
-  void publish_state_(sensor::Sensor *sensor, float value, bool change_only = false);
-  void publish_state_(text_sensor::TextSensor *sensor, std::string value);
+  void run_();
+  void read_(bsec_bme_settings_t bme680_settings);
+  void publish_(const bsec_output_t * outputs, uint8_t num_outputs);
 
-  Bsec bsec_;
-  bsec_library_return_t last_bsec_status_{BSEC_OK};
-  int8_t last_bme680_status_{BME680_OK};
-  float temperature_offset_{0};
+  bool check_bsec_status_();
+
+  void load_state_();
+  void save_state_(uint8_t accuracy);
+
+  void publish_sensor_state_(sensor::Sensor *sensor, float value, bool change_only = false);
+  void publish_sensor_state_(text_sensor::TextSensor *sensor, std::string value);
+
+  void set_config_(const uint8_t *config);
+  void update_subscription_(float sample_rate);
+  void set_state_(uint8_t *state);
+  int64_t get_time_ns_();
+
+  struct bme680_dev bme680_;
+  bsec_library_return_t bsec_status_{BSEC_OK};
+  int8_t bme680_status_{BME680_OK};
+
+  int64_t last_time_ms_{0};
+  uint32_t millis_overflow_counter_{0};
+  int64_t next_call_ns_{0};
+
   ESPPreferenceObject bsec_state_;
-  uint32_t state_save_interval_{21600000};  // 6 hours - 4 times a day
+  uint32_t state_save_interval_ms_{21600000};  // 6 hours - 4 times a day
+  unsigned long last_state_save_ms_ = 0;
+
+  float temperature_offset_{0};
   IAQMode iaq_mode_{IAQ_MODE_STATIC};
   SampleRate sample_rate_{SAMPLE_RATE_LP};
 


### PR DESCRIPTION
This removes usage of the Bosch provided Bsec helper class and instead interfaces more directly with the underlying library. 
Most importantly this allows removal of the forced delay within the component loop which was causing various problems within the ESPHome ecosystem.

Unfortunately due to the added timing complexities this does mean that I have removed support for reading from multiple sensors as it would take considerable extra effort to appropriately manage the bsec library state.