### PR TITLE
Allow sample rate overrides for T/P/H sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ bme680_bsec:
 
     # Sample rate
     # -----------
+    # This controls the sampling rate for gas-dependant sensors and will govern the interval at which the sensor heater is operated.
+    # By default this rate will also be used for temperature, pressure and humidity sensors but these can be overridden on a per-sensor level if required.
     # Available options:
     # - lp (low power - samples every 3 seconds)
     # - ulp (ultra low power - samples every 5 minutes)
     # Default: lp
-    sample_rate: lp
+    sample_rate: ulp
 
     # Interval at which to save BSEC state
     # ------------------------------------
@@ -73,16 +75,19 @@ sensor:
     temperature:
       # Temperature in °C
       name: "BME680 Temperature"
+      sample_rate: lp
       filters:
         - median
     pressure:
       # Pressure in hPa
       name: "BME680 Pressure"
+      sample_rate: lp
       filters:
         - median
     humidity:
       # Relative humidity %
       name: "BME680 Humidity"
+      sample_rate: lp
       filters:
         - median
     gas_resistance:

--- a/bme680_bsec/__init__.py
+++ b/bme680_bsec/__init__.py
@@ -3,41 +3,49 @@ import esphome.config_validation as cv
 from esphome.components import i2c
 from esphome.const import CONF_ID
 
-CODEOWNERS = ['@trvrnrth']
-DEPENDENCIES = ['i2c']
-AUTO_LOAD = ['sensor', 'text_sensor']
+CODEOWNERS = ["@trvrnrth"]
+DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["sensor", "text_sensor"]
 
-CONF_BME680_BSEC_ID = 'bme680_bsec_id'
-CONF_TEMPERATURE_OFFSET = 'temperature_offset'
-CONF_IAQ_MODE = 'iaq_mode'
-CONF_SAMPLE_RATE = 'sample_rate'
-CONF_STATE_SAVE_INTERVAL = 'state_save_interval'
+CONF_BME680_BSEC_ID = "bme680_bsec_id"
+CONF_TEMPERATURE_OFFSET = "temperature_offset"
+CONF_IAQ_MODE = "iaq_mode"
+CONF_SAMPLE_RATE = "sample_rate"
+CONF_STATE_SAVE_INTERVAL = "state_save_interval"
 
-bme680_bsec_ns = cg.esphome_ns.namespace('bme680_bsec')
+bme680_bsec_ns = cg.esphome_ns.namespace("bme680_bsec")
 
-IAQMode = bme680_bsec_ns.enum('IAQMode')
+IAQMode = bme680_bsec_ns.enum("IAQMode")
 IAQ_MODE_OPTIONS = {
-    'STATIC': IAQMode.IAQ_MODE_STATIC,
-    'MOBILE': IAQMode.IAQ_MODE_MOBILE,
+    "STATIC": IAQMode.IAQ_MODE_STATIC,
+    "MOBILE": IAQMode.IAQ_MODE_MOBILE,
 }
 
-SampleRate = bme680_bsec_ns.enum('SampleRate')
+SampleRate = bme680_bsec_ns.enum("SampleRate")
 SAMPLE_RATE_OPTIONS = {
-    'LP': SampleRate.SAMPLE_RATE_LP,
-    'ULP': SampleRate.SAMPLE_RATE_ULP,
+    "LP": SampleRate.SAMPLE_RATE_LP,
+    "ULP": SampleRate.SAMPLE_RATE_ULP,
 }
 
-BME680BSECComponent = bme680_bsec_ns.class_('BME680BSECComponent', cg.Component, i2c.I2CDevice)
+BME680BSECComponent = bme680_bsec_ns.class_(
+    "BME680BSECComponent", cg.Component, i2c.I2CDevice
+)
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(BME680BSECComponent),
-    cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
-    cv.Optional(CONF_IAQ_MODE, default='STATIC'):
-        cv.enum(IAQ_MODE_OPTIONS, upper=True),
-    cv.Optional(CONF_SAMPLE_RATE, default='LP'):
-        cv.enum(SAMPLE_RATE_OPTIONS, upper=True),
-    cv.Optional(CONF_STATE_SAVE_INTERVAL, default='6hours'): cv.positive_time_period_minutes,
-}).extend(i2c.i2c_device_schema(0x76))
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(BME680BSECComponent),
+        cv.Optional(CONF_TEMPERATURE_OFFSET, default=0): cv.temperature,
+        cv.Optional(CONF_IAQ_MODE, default="STATIC"): cv.enum(
+            IAQ_MODE_OPTIONS, upper=True
+        ),
+        cv.Optional(CONF_SAMPLE_RATE, default="LP"): cv.enum(
+            SAMPLE_RATE_OPTIONS, upper=True
+        ),
+        cv.Optional(
+            CONF_STATE_SAVE_INTERVAL, default="6hours"
+        ): cv.positive_time_period_minutes,
+    }
+).extend(i2c.i2c_device_schema(0x76))
 
 
 def to_code(config):
@@ -48,7 +56,9 @@ def to_code(config):
     cg.add(var.set_temperature_offset(config[CONF_TEMPERATURE_OFFSET]))
     cg.add(var.set_iaq_mode(config[CONF_IAQ_MODE]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
-    cg.add(var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds))
+    cg.add(
+        var.set_state_save_interval(config[CONF_STATE_SAVE_INTERVAL].total_milliseconds)
+    )
 
-    cg.add_build_flag('-DUSING_BSEC')
-    cg.add_library('BSEC Software Library', '1.6.1480')
+    cg.add_define("USE_BSEC")
+    cg.add_library("BSEC Software Library", "1.6.1480")

--- a/bme680_bsec/bme680_bsec.cpp
+++ b/bme680_bsec/bme680_bsec.cpp
@@ -1,5 +1,3 @@
-#ifdef USING_BSEC
-
 #include "bme680_bsec.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
@@ -7,12 +5,12 @@
 
 namespace esphome {
 namespace bme680_bsec {
-
+#ifdef USE_BSEC
 static const char *TAG = "bme680_bsec.sensor";
 
 static const std::string IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
 
-BME680BSECComponent * BME680BSECComponent::instance;
+BME680BSECComponent *BME680BSECComponent::instance;
 
 void BME680BSECComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up BME680 via BSEC...");
@@ -30,7 +28,6 @@ void BME680BSECComponent::setup() {
   this->bme680_.write = BME680BSECComponent::write_bytes_wrapper;
   this->bme680_.delay_ms = BME680BSECComponent::delay_ms;
   this->bme680_.amb_temp = 25;
-  this->bme680_.power_mode = BME680_FORCED_MODE;
 
   this->bme680_status_ = bme680_init(&this->bme680_);
   if (this->bme680_status_ != BME680_OK) {
@@ -43,14 +40,13 @@ void BME680BSECComponent::setup() {
 #include "config/generic_33v_300s_28d/bsec_iaq.txt"
     };
     this->set_config_(bsec_config);
-    this->update_subscription_(BSEC_SAMPLE_RATE_ULP);
   } else {
     const uint8_t bsec_config[] = {
 #include "config/generic_33v_3s_28d/bsec_iaq.txt"
     };
     this->set_config_(bsec_config);
-    this->update_subscription_(BSEC_SAMPLE_RATE_LP);
   }
+  this->update_subscription_();
   if (this->bsec_status_ != BSEC_OK) {
     this->mark_failed();
     return;
@@ -64,55 +60,64 @@ void BME680BSECComponent::set_config_(const uint8_t *config) {
   this->bsec_status_ = bsec_set_configuration(config, BSEC_MAX_PROPERTY_BLOB_SIZE, work_buffer, sizeof(work_buffer));
 }
 
-void BME680BSECComponent::update_subscription_(float sample_rate) {
+float BME680BSECComponent::calc_sensor_sample_rate_(SampleRate sample_rate) {
+  if (sample_rate == SAMPLE_RATE_DEFAULT) {
+    sample_rate = this->sample_rate_;
+  }
+  return sample_rate == SAMPLE_RATE_ULP ? BSEC_SAMPLE_RATE_ULP : BSEC_SAMPLE_RATE_LP;
+}
+
+void BME680BSECComponent::update_subscription_() {
   bsec_sensor_configuration_t virtual_sensors[BSEC_NUMBER_OUTPUTS];
   int num_virtual_sensors = 0;
 
   if (this->iaq_sensor_) {
-    virtual_sensors[num_virtual_sensors].sensor_id = this->iaq_mode_ == IAQ_MODE_STATIC ? BSEC_OUTPUT_STATIC_IAQ : BSEC_OUTPUT_IAQ;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sensor_id =
+        this->iaq_mode_ == IAQ_MODE_STATIC ? BSEC_OUTPUT_STATIC_IAQ : BSEC_OUTPUT_IAQ;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(SAMPLE_RATE_DEFAULT);
     num_virtual_sensors++;
   }
 
   if (this->co2_equivalent_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_CO2_EQUIVALENT;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(SAMPLE_RATE_DEFAULT);
     num_virtual_sensors++;
   }
 
   if (this->breath_voc_equivalent_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_BREATH_VOC_EQUIVALENT;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(SAMPLE_RATE_DEFAULT);
     num_virtual_sensors++;
   }
 
   if (this->pressure_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_PRESSURE;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(this->pressure_sample_rate_);
     num_virtual_sensors++;
   }
 
   if (this->gas_resistance_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_RAW_GAS;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(SAMPLE_RATE_DEFAULT);
     num_virtual_sensors++;
   }
 
   if (this->temperature_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(this->temperature_sample_rate_);
     num_virtual_sensors++;
   }
 
   if (this->humidity_sensor_) {
     virtual_sensors[num_virtual_sensors].sensor_id = BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY;
-    virtual_sensors[num_virtual_sensors].sample_rate = sample_rate;
+    virtual_sensors[num_virtual_sensors].sample_rate = this->calc_sensor_sample_rate_(this->humidity_sample_rate_);
     num_virtual_sensors++;
   }
 
   bsec_sensor_configuration_t sensor_settings[BSEC_MAX_PHYSICAL_SENSOR];
   uint8_t num_sensor_settings = BSEC_MAX_PHYSICAL_SENSOR;
-  this->bsec_status_ = bsec_update_subscription(virtual_sensors, num_virtual_sensors, sensor_settings, &num_sensor_settings);
+  this->bsec_status_ =
+      bsec_update_subscription(virtual_sensors, num_virtual_sensors, sensor_settings, &num_sensor_settings);
 }
 
 void BME680BSECComponent::dump_config() {
@@ -120,22 +125,27 @@ void BME680BSECComponent::dump_config() {
 
   bsec_version_t version;
   bsec_get_version(&version);
-  ESP_LOGCONFIG(TAG, "  BSEC Version: %d.%d.%d.%d", version.major, version.minor, version.major_bugfix, version.minor_bugfix);
-  
+  ESP_LOGCONFIG(TAG, "  BSEC Version: %d.%d.%d.%d", version.major, version.minor, version.major_bugfix,
+                version.minor_bugfix);
+
   LOG_I2C_DEVICE(this);
 
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Communication failed (BSEC Status: %d, BME680 Status: %d)", this->bsec_status_, this->bme680_status_);
+    ESP_LOGE(TAG, "Communication failed (BSEC Status: %d, BME680 Status: %d)", this->bsec_status_,
+             this->bme680_status_);
   }
 
   ESP_LOGCONFIG(TAG, "  Temperature Offset: %.2f", this->temperature_offset_);
   ESP_LOGCONFIG(TAG, "  IAQ Mode: %s", this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile");
-  ESP_LOGCONFIG(TAG, "  Sample Rate: %s", this->sample_rate_ == SAMPLE_RATE_ULP ? "ULP" : "LP");
+  ESP_LOGCONFIG(TAG, "  Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_));
   ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_ms_);
 
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->temperature_sample_rate_));
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->pressure_sample_rate_));
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+  ESP_LOGCONFIG(TAG, "    Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->humidity_sample_rate_));
   LOG_SENSOR("  ", "Gas Resistance", this->gas_resistance_sensor_);
   LOG_SENSOR("  ", "IAQ", this->iaq_sensor_);
   LOG_SENSOR("  ", "Numeric IAQ Accuracy", this->iaq_accuracy_sensor_);
@@ -177,33 +187,55 @@ void BME680BSECComponent::run_() {
   }
   this->next_call_ns_ = bme680_settings.next_call;
 
-  this->bme680_.gas_sett.run_gas = bme680_settings.run_gas;
-  this->bme680_.tph_sett.os_hum = bme680_settings.humidity_oversampling;
-  this->bme680_.tph_sett.os_temp = bme680_settings.temperature_oversampling;
-  this->bme680_.tph_sett.os_pres = bme680_settings.pressure_oversampling;
-  this->bme680_.gas_sett.heatr_temp = bme680_settings.heater_temperature;
-  this->bme680_.gas_sett.heatr_dur = bme680_settings.heating_duration;
-  uint16_t desired_settings = BME680_OST_SEL | BME680_OSP_SEL | BME680_OSH_SEL | BME680_FILTER_SEL | BME680_GAS_SENSOR_SEL;
-  this->bme680_status_ = bme680_set_sensor_settings(desired_settings, &this->bme680_);
-  if (this->bme680_status_ != BME680_OK) {
-    ESP_LOGW(TAG, "Failed to set sensor settings (BME680 Error Code %d)", this->bme680_status_);
-    return;
-  }
+  if (bme680_settings.trigger_measurement) {
+    this->bme680_.tph_sett.os_temp = bme680_settings.temperature_oversampling;
+    this->bme680_.tph_sett.os_pres = bme680_settings.pressure_oversampling;
+    this->bme680_.tph_sett.os_hum = bme680_settings.humidity_oversampling;
+    this->bme680_.gas_sett.run_gas = bme680_settings.run_gas;
+    this->bme680_.gas_sett.heatr_temp = bme680_settings.heater_temperature;
+    this->bme680_.gas_sett.heatr_dur = bme680_settings.heating_duration;
+    this->bme680_.power_mode = BME680_FORCED_MODE;
+    uint16_t desired_settings = BME680_OST_SEL | BME680_OSP_SEL | BME680_OSH_SEL | BME680_GAS_SENSOR_SEL;
+    this->bme680_status_ = bme680_set_sensor_settings(desired_settings, &this->bme680_);
+    if (this->bme680_status_ != BME680_OK) {
+      ESP_LOGW(TAG, "Failed to set sensor settings (BME680 Error Code %d)", this->bme680_status_);
+      return;
+    }
 
-  this->bme680_status_ = bme680_set_sensor_mode(&this->bme680_);
-  if (this->bme680_status_ != BME680_OK) {
-    ESP_LOGW(TAG, "Failed to set sensor mode (BME680 Error Code %d)", this->bme680_status_);
-    return;
-  }
+    this->bme680_status_ = bme680_set_sensor_mode(&this->bme680_);
+    if (this->bme680_status_ != BME680_OK) {
+      ESP_LOGW(TAG, "Failed to set sensor mode (BME680 Error Code %d)", this->bme680_status_);
+      return;
+    }
 
-  uint16_t meas_dur = 0;
-  bme680_get_profile_dur(&meas_dur, &this->bme680_);
-  ESP_LOGV(TAG, "Queueing read in %ums", meas_dur);
-  this->set_timeout("read", meas_dur, [this, bme680_settings]() { this->read_(bme680_settings); });
+    uint16_t meas_dur = 0;
+    bme680_get_profile_dur(&meas_dur, &this->bme680_);
+    ESP_LOGV(TAG, "Queueing read in %ums", meas_dur);
+    this->set_timeout("read", meas_dur,
+                      [this, curr_time_ns, bme680_settings]() { this->read_(curr_time_ns, bme680_settings); });
+  } else {
+    ESP_LOGV(TAG, "Measurement not required");
+    this->read_(curr_time_ns, bme680_settings);
+  }
 }
 
-void BME680BSECComponent::read_(bsec_bme_settings_t bme680_settings) {
+void BME680BSECComponent::read_(int64_t trigger_time_ns, bsec_bme_settings_t bme680_settings) {
   ESP_LOGV(TAG, "Reading data");
+
+  if (bme680_settings.trigger_measurement) {
+    while (this->bme680_.power_mode != BME680_SLEEP_MODE) {
+      this->bme680_status_ = bme680_get_sensor_mode(&this->bme680_);
+      if (this->bme680_status_ != BME680_OK) {
+        ESP_LOGW(TAG, "Failed to get sensor mode (BME680 Error Code %d)", this->bme680_status_);
+      }
+    }
+  }
+
+  if (!bme680_settings.process_data) {
+    ESP_LOGV(TAG, "Data processing not required");
+    return;
+  }
+
   struct bme680_field_data data;
   this->bme680_status_ = bme680_get_sensor_data(&data, &this->bme680_);
 
@@ -216,39 +248,42 @@ void BME680BSECComponent::read_(bsec_bme_settings_t bme680_settings) {
     return;
   }
 
-  bsec_input_t inputs[BSEC_MAX_PHYSICAL_SENSOR]; // Temperature, Pressure, Humidity & Gas Resistance
+  bsec_input_t inputs[BSEC_MAX_PHYSICAL_SENSOR];  // Temperature, Pressure, Humidity & Gas Resistance
   uint8_t num_inputs = 0;
-  int64_t curr_time_ns = this->get_time_ns_();
 
   if (bme680_settings.process_data & BSEC_PROCESS_TEMPERATURE) {
     inputs[num_inputs].sensor_id = BSEC_INPUT_TEMPERATURE;
     inputs[num_inputs].signal = data.temperature / 100.0f;
-    inputs[num_inputs].time_stamp = curr_time_ns;
+    inputs[num_inputs].time_stamp = trigger_time_ns;
     num_inputs++;
 
     // Temperature offset from the real temperature due to external heat sources
     inputs[num_inputs].sensor_id = BSEC_INPUT_HEATSOURCE;
     inputs[num_inputs].signal = this->temperature_offset_;
-    inputs[num_inputs].time_stamp = curr_time_ns;
+    inputs[num_inputs].time_stamp = trigger_time_ns;
     num_inputs++;
   }
   if (bme680_settings.process_data & BSEC_PROCESS_HUMIDITY) {
     inputs[num_inputs].sensor_id = BSEC_INPUT_HUMIDITY;
     inputs[num_inputs].signal = data.humidity / 1000.0f;
-    inputs[num_inputs].time_stamp = curr_time_ns;
+    inputs[num_inputs].time_stamp = trigger_time_ns;
     num_inputs++;
   }
   if (bme680_settings.process_data & BSEC_PROCESS_PRESSURE) {
     inputs[num_inputs].sensor_id = BSEC_INPUT_PRESSURE;
     inputs[num_inputs].signal = data.pressure;
-    inputs[num_inputs].time_stamp = curr_time_ns;
+    inputs[num_inputs].time_stamp = trigger_time_ns;
     num_inputs++;
   }
   if (bme680_settings.process_data & BSEC_PROCESS_GAS) {
-    inputs[num_inputs].sensor_id = BSEC_INPUT_GASRESISTOR;
-    inputs[num_inputs].signal = data.gas_resistance;
-    inputs[num_inputs].time_stamp = curr_time_ns;
-    num_inputs++;
+    if (data.status & BME680_GASM_VALID_MSK) {
+      inputs[num_inputs].sensor_id = BSEC_INPUT_GASRESISTOR;
+      inputs[num_inputs].signal = data.gas_resistance;
+      inputs[num_inputs].time_stamp = trigger_time_ns;
+      num_inputs++;
+    } else {
+      ESP_LOGD(TAG, "BME680 did not report gas data");
+    }
   }
   if (num_inputs < 1) {
     ESP_LOGD(TAG, "No signal inputs available for BSEC");
@@ -270,7 +305,7 @@ void BME680BSECComponent::read_(bsec_bme_settings_t bme680_settings) {
   this->publish_(outputs, num_outputs);
 }
 
-void BME680BSECComponent::publish_(const bsec_output_t * outputs, uint8_t num_outputs) {
+void BME680BSECComponent::publish_(const bsec_output_t *outputs, uint8_t num_outputs) {
   ESP_LOGV(TAG, "Publishing sensor states");
   for (uint8_t i = 0; i < num_outputs; i++) {
     switch (outputs[i].sensor_id) {
@@ -314,7 +349,7 @@ int64_t BME680BSECComponent::get_time_ns_() {
   }
   this->last_time_ms_ = time_ms;
 
-  return (time_ms + ((int64_t)this->millis_overflow_counter_ << 32)) * INT64_C(1000000);
+  return (time_ms + ((int64_t) this->millis_overflow_counter_ << 32)) * INT64_C(1000000);
 }
 
 void BME680BSECComponent::publish_sensor_state_(sensor::Sensor *sensor, float value, bool change_only) {
@@ -371,7 +406,8 @@ void BME680BSECComponent::save_state_(uint8_t accuracy) {
   uint8_t work_buffer[BSEC_MAX_STATE_BLOB_SIZE];
   uint32_t num_serialized_state = BSEC_MAX_STATE_BLOB_SIZE;
 
-  this->bsec_status_ = bsec_get_state(0, state, BSEC_MAX_STATE_BLOB_SIZE, work_buffer, BSEC_MAX_STATE_BLOB_SIZE, &num_serialized_state);
+  this->bsec_status_ =
+      bsec_get_state(0, state, BSEC_MAX_STATE_BLOB_SIZE, work_buffer, BSEC_MAX_STATE_BLOB_SIZE, &num_serialized_state);
   if (this->bsec_status_ != BSEC_OK) {
     ESP_LOGW(TAG, "Failed fetch state for save (BSEC Error Code %d)", this->bsec_status_);
     return;
@@ -385,8 +421,6 @@ void BME680BSECComponent::save_state_(uint8_t accuracy) {
 
   ESP_LOGI(TAG, "Saved state");
 }
-
+#endif
 }  // namespace bme680_bsec
 }  // namespace esphome
-
-#endif

--- a/bme680_bsec/bme680_bsec.h
+++ b/bme680_bsec/bme680_bsec.h
@@ -1,5 +1,3 @@
-#ifdef USING_BSEC
-
 #pragma once
 
 #include "esphome/core/component.h"
@@ -7,11 +5,15 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/preferences.h"
-#include <bsec.h>
 #include <map>
+
+#ifdef USE_BSEC
+#include <bsec.h>
+#endif
 
 namespace esphome {
 namespace bme680_bsec {
+#ifdef USE_BSEC
 
 enum IAQMode {
   IAQ_MODE_STATIC = 0,
@@ -21,34 +23,33 @@ enum IAQMode {
 enum SampleRate {
   SAMPLE_RATE_LP = 0,
   SAMPLE_RATE_ULP = 1,
+  SAMPLE_RATE_DEFAULT = 2,
 };
+
+#define BME680_BSEC_SAMPLE_RATE_LOG(r) (r == SAMPLE_RATE_DEFAULT ? "Default" : (r == SAMPLE_RATE_ULP ? "ULP" : "LP"))
 
 class BME680BSECComponent : public Component, public i2c::I2CDevice {
  public:
   void set_temperature_offset(float offset) { this->temperature_offset_ = offset; }
   void set_iaq_mode(IAQMode iaq_mode) { this->iaq_mode_ = iaq_mode; }
-  void set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
   void set_state_save_interval(uint32_t interval) { this->state_save_interval_ms_ = interval; }
 
-  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
-  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
-  void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
-  void set_gas_resistance_sensor(sensor::Sensor *gas_resistance_sensor) {
-    gas_resistance_sensor_ = gas_resistance_sensor;
-  }
-  void set_iaq_sensor(sensor::Sensor *iaq_sensor) { iaq_sensor_ = iaq_sensor; }
-  void set_iaq_accuracy_text_sensor(text_sensor::TextSensor *iaq_accuracy_text_sensor) {
-    iaq_accuracy_text_sensor_ = iaq_accuracy_text_sensor;
-  }
-  void set_iaq_accuracy_sensor(sensor::Sensor *iaq_accuracy_sensor) { iaq_accuracy_sensor_ = iaq_accuracy_sensor; }
-  void set_co2_equivalent_sensor(sensor::Sensor *co2_equivalent_sensor) {
-    co2_equivalent_sensor_ = co2_equivalent_sensor;
-  }
-  void set_breath_voc_equivalent_sensor(sensor::Sensor *breath_voc_equivalent_sensor) {
-    breath_voc_equivalent_sensor_ = breath_voc_equivalent_sensor;
-  }
+  void set_sample_rate(SampleRate sample_rate) { this->sample_rate_ = sample_rate; }
+  void set_temperature_sample_rate(SampleRate sample_rate) { this->temperature_sample_rate_ = sample_rate; }
+  void set_pressure_sample_rate(SampleRate sample_rate) { this->pressure_sample_rate_ = sample_rate; }
+  void set_humidity_sample_rate(SampleRate sample_rate) { this->humidity_sample_rate_ = sample_rate; }
 
-  static BME680BSECComponent * instance;
+  void set_temperature_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
+  void set_pressure_sensor(sensor::Sensor *sensor) { this->pressure_sensor_ = sensor; }
+  void set_humidity_sensor(sensor::Sensor *sensor) { this->humidity_sensor_ = sensor; }
+  void set_gas_resistance_sensor(sensor::Sensor *sensor) { this->gas_resistance_sensor_ = sensor; }
+  void set_iaq_sensor(sensor::Sensor *sensor) { this->iaq_sensor_ = sensor; }
+  void set_iaq_accuracy_text_sensor(text_sensor::TextSensor *sensor) { this->iaq_accuracy_text_sensor_ = sensor; }
+  void set_iaq_accuracy_sensor(sensor::Sensor *sensor) { this->iaq_accuracy_sensor_ = sensor; }
+  void set_co2_equivalent_sensor(sensor::Sensor *sensor) { this->co2_equivalent_sensor_ = sensor; }
+  void set_breath_voc_equivalent_sensor(sensor::Sensor *sensor) { this->breath_voc_equivalent_sensor_ = sensor; }
+
+  static BME680BSECComponent *instance;
   static int8_t read_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len);
   static int8_t write_bytes_wrapper(uint8_t address, uint8_t a_register, uint8_t *data, uint16_t len);
   static void delay_ms(uint32_t period);
@@ -60,11 +61,12 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
  protected:
   void set_config_(const uint8_t *config);
-  void update_subscription_(float sample_rate);
+  float calc_sensor_sample_rate_(SampleRate sample_rate);
+  void update_subscription_();
 
   void run_();
-  void read_(bsec_bme_settings_t bme680_settings);
-  void publish_(const bsec_output_t * outputs, uint8_t num_outputs);
+  void read_(int64_t trigger_time_ns, bsec_bme_settings_t bme680_settings);
+  void publish_(const bsec_output_t *outputs, uint8_t num_outputs);
   int64_t get_time_ns_();
 
   void publish_sensor_state_(sensor::Sensor *sensor, float value, bool change_only = false);
@@ -87,7 +89,11 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
   float temperature_offset_{0};
   IAQMode iaq_mode_{IAQ_MODE_STATIC};
-  SampleRate sample_rate_{SAMPLE_RATE_LP};
+
+  SampleRate sample_rate_{SAMPLE_RATE_LP};  // Core/gas sample rate
+  SampleRate temperature_sample_rate_{SAMPLE_RATE_DEFAULT};
+  SampleRate pressure_sample_rate_{SAMPLE_RATE_DEFAULT};
+  SampleRate humidity_sample_rate_{SAMPLE_RATE_DEFAULT};
 
   sensor::Sensor *temperature_sensor_;
   sensor::Sensor *pressure_sensor_;
@@ -99,8 +105,6 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   sensor::Sensor *co2_equivalent_sensor_;
   sensor::Sensor *breath_voc_equivalent_sensor_;
 };
-
+#endif
 }  // namespace bme680_bsec
 }  // namespace esphome
-
-#endif

--- a/bme680_bsec/sensor.py
+++ b/bme680_bsec/sensor.py
@@ -1,64 +1,103 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
-from esphome.const import CONF_TEMPERATURE, CONF_PRESSURE, CONF_HUMIDITY, CONF_GAS_RESISTANCE, \
-    UNIT_CELSIUS, UNIT_EMPTY, UNIT_HECTOPASCAL, UNIT_PERCENT, UNIT_OHM, UNIT_PARTS_PER_MILLION, \
-    ICON_THERMOMETER, ICON_GAUGE, ICON_WATER_PERCENT, ICON_GAS_CYLINDER
+from esphome.const import (
+    CONF_GAS_RESISTANCE,
+    CONF_HUMIDITY,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    UNIT_CELSIUS,
+    UNIT_EMPTY,
+    UNIT_HECTOPASCAL,
+    UNIT_OHM,
+    UNIT_PARTS_PER_MILLION,
+    UNIT_PERCENT,
+    ICON_GAS_CYLINDER,
+    ICON_GAUGE,
+    ICON_THERMOMETER,
+    ICON_WATER_PERCENT,
+)
 from esphome.core import coroutine
-from . import BME680BSECComponent, CONF_BME680_BSEC_ID
+from . import (
+    BME680BSECComponent,
+    CONF_BME680_BSEC_ID,
+    CONF_SAMPLE_RATE,
+    SAMPLE_RATE_OPTIONS,
+)
 
-DEPENDENCIES = ['bme680_bsec']
+DEPENDENCIES = ["bme680_bsec"]
 
-CONF_IAQ = 'iaq'
-CONF_IAQ_ACCURACY = 'iaq_accuracy'
-CONF_CO2_EQUIVALENT = 'co2_equivalent'
-CONF_BREATH_VOC_EQUIVALENT = 'breath_voc_equivalent'
-UNIT_IAQ = 'IAQ'
-ICON_ACCURACY = 'mdi:checkbox-marked-circle-outline'
-ICON_TEST_TUBE = 'mdi:test-tube'
+CONF_IAQ = "iaq"
+CONF_IAQ_ACCURACY = "iaq_accuracy"
+CONF_CO2_EQUIVALENT = "co2_equivalent"
+CONF_BREATH_VOC_EQUIVALENT = "breath_voc_equivalent"
+UNIT_IAQ = "IAQ"
+ICON_ACCURACY = "mdi:checkbox-marked-circle-outline"
+ICON_TEST_TUBE = "mdi:test-tube"
 
-TYPES = {
-    CONF_TEMPERATURE: 'set_temperature_sensor',
-    CONF_PRESSURE: 'set_pressure_sensor',
-    CONF_HUMIDITY: 'set_humidity_sensor',
-    CONF_GAS_RESISTANCE: 'set_gas_resistance_sensor',
-    CONF_IAQ: 'set_iaq_sensor',
-    CONF_IAQ_ACCURACY: 'set_iaq_accuracy_sensor',
-    CONF_CO2_EQUIVALENT: 'set_co2_equivalent_sensor',
-    CONF_BREATH_VOC_EQUIVALENT: 'set_breath_voc_equivalent_sensor',
-}
+TYPES = [
+    CONF_TEMPERATURE,
+    CONF_PRESSURE,
+    CONF_HUMIDITY,
+    CONF_GAS_RESISTANCE,
+    CONF_IAQ,
+    CONF_IAQ_ACCURACY,
+    CONF_CO2_EQUIVALENT,
+    CONF_BREATH_VOC_EQUIVALENT,
+]
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
-    cv.Optional(CONF_TEMPERATURE):
-        sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1),
-    cv.Optional(CONF_PRESSURE):
-        sensor.sensor_schema(UNIT_HECTOPASCAL, ICON_GAUGE, 1),
-    cv.Optional(CONF_HUMIDITY):
-        sensor.sensor_schema(UNIT_PERCENT, ICON_WATER_PERCENT, 1),
-    cv.Optional(CONF_GAS_RESISTANCE):
-        sensor.sensor_schema(UNIT_OHM, ICON_GAS_CYLINDER, 0),
-    cv.Optional(CONF_IAQ):
-        sensor.sensor_schema(UNIT_IAQ, ICON_GAUGE, 0),
-    cv.Optional(CONF_IAQ_ACCURACY):
-        sensor.sensor_schema(UNIT_EMPTY, ICON_ACCURACY, 0),
-    cv.Optional(CONF_CO2_EQUIVALENT):
-        sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1),
-    cv.Optional(CONF_BREATH_VOC_EQUIVALENT):
-        sensor.sensor_schema(UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1),
-})
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
+        cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+            UNIT_CELSIUS, ICON_THERMOMETER, 1, DEVICE_CLASS_TEMPERATURE
+        ).extend(
+            {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
+        ),
+        cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+            UNIT_HECTOPASCAL, ICON_GAUGE, 1, DEVICE_CLASS_PRESSURE
+        ).extend(
+            {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
+        ),
+        cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+            UNIT_PERCENT, ICON_WATER_PERCENT, 1, DEVICE_CLASS_HUMIDITY
+        ).extend(
+            {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
+        ),
+        cv.Optional(CONF_GAS_RESISTANCE): sensor.sensor_schema(
+            UNIT_OHM, ICON_GAS_CYLINDER, 0, DEVICE_CLASS_EMPTY
+        ),
+        cv.Optional(CONF_IAQ): sensor.sensor_schema(
+            UNIT_IAQ, ICON_GAUGE, 0, DEVICE_CLASS_EMPTY
+        ),
+        cv.Optional(CONF_IAQ_ACCURACY): sensor.sensor_schema(
+            UNIT_EMPTY, ICON_ACCURACY, 0, DEVICE_CLASS_EMPTY
+        ),
+        cv.Optional(CONF_CO2_EQUIVALENT): sensor.sensor_schema(
+            UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+        ),
+        cv.Optional(CONF_BREATH_VOC_EQUIVALENT): sensor.sensor_schema(
+            UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+        ),
+    }
+)
 
 
 @coroutine
-def setup_conf(config, key, hub, funcName):
+def setup_conf(config, key, hub):
     if key in config:
         conf = config[key]
-        var = yield sensor.new_sensor(conf)
-        func = getattr(hub, funcName)
-        cg.add(func(var))
+        sens = yield sensor.new_sensor(conf)
+        cg.add(getattr(hub, f"set_{key}_sensor")(sens))
+        if CONF_SAMPLE_RATE in conf:
+            cg.add(getattr(hub, f"set_{key}_sample_rate")(conf[CONF_SAMPLE_RATE]))
 
 
 def to_code(config):
     hub = yield cg.get_variable(config[CONF_BME680_BSEC_ID])
-    for key, funcName in TYPES.items():
-        yield setup_conf(config, key, hub, funcName)
+    for key in TYPES:
+        yield setup_conf(config, key, hub)

--- a/bme680_bsec/text_sensor.py
+++ b/bme680_bsec/text_sensor.py
@@ -5,36 +5,36 @@ from esphome.const import CONF_ID, CONF_ICON
 from esphome.core import coroutine
 from . import BME680BSECComponent, CONF_BME680_BSEC_ID
 
-DEPENDENCIES = ['bme680_bsec']
+DEPENDENCIES = ["bme680_bsec"]
 
-CONF_IAQ_ACCURACY = 'iaq_accuracy'
-ICON_ACCURACY = 'mdi:checkbox-marked-circle-outline'
+CONF_IAQ_ACCURACY = "iaq_accuracy"
+ICON_ACCURACY = "mdi:checkbox-marked-circle-outline"
 
-TYPES = {
-    CONF_IAQ_ACCURACY: 'set_iaq_accuracy_text_sensor',
-}
+TYPES = [CONF_IAQ_ACCURACY]
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
-    cv.Optional(CONF_IAQ_ACCURACY):
-        text_sensor.TEXT_SENSOR_SCHEMA.extend({
-            cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-            cv.Optional(CONF_ICON, default=ICON_ACCURACY): cv.icon,
-        }),
-})
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
+        cv.Optional(CONF_IAQ_ACCURACY): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                cv.Optional(CONF_ICON, default=ICON_ACCURACY): cv.icon,
+            }
+        ),
+    }
+)
 
 
 @coroutine
-def setup_conf(config, key, hub, funcName):
+def setup_conf(config, key, hub):
     if key in config:
         conf = config[key]
-        var = cg.new_Pvariable(conf[CONF_ID])
-        yield text_sensor.register_text_sensor(var, conf)
-        func = getattr(hub, funcName)
-        cg.add(func(var))
+        sens = cg.new_Pvariable(conf[CONF_ID])
+        yield text_sensor.register_text_sensor(sens, conf)
+        cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))
 
 
 def to_code(config):
     hub = yield cg.get_variable(config[CONF_BME680_BSEC_ID])
-    for key, funcName in TYPES.items():
-        yield setup_conf(config, key, hub, funcName)
+    for key in TYPES:
+        yield setup_conf(config, key, hub)


### PR DESCRIPTION
This allows for the common request of being able to run the
gas-dependant sensors/calculations in ULP mode with more frequent
LP temperature/pressure/humidity readings.

In that setup the heater only runs every 5 minutes reducing
consumption but still allowing highly reactive T/P/H readings.

Other combinations are also possible but they'll not be so useful.

If no per-sensor overrides are given then they will run at the sample
rate configured at platform level.

Also included in this PR are some tidy-ups to:
- improve code readability and formatting
- clear up a compile time warning relating to gate-keeper define
- add a couple of extra sensor status safety checks
- specify sensor device classes