### PR TITLE
Fix for broken dependencies with esphome 2022.7.0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The [I2C Bus](https://esphome.io/components/i2c.html#i2c) must be set up in orde
 ## Minimal configuration
 The following configuration shows the minimal set up to read temperature and humidity from the sensor.
 ```yaml
+esphome:
+  libraries:
+    - SPI
+
 i2c:
 
 bme680_bsec:

--- a/components/bme680_bsec/bme680_bsec.cpp
+++ b/components/bme680_bsec/bme680_bsec.cpp
@@ -381,7 +381,7 @@ void BME680BSECComponent::delay_ms(uint32_t period) {
 
 void BME680BSECComponent::load_state_() {
   uint32_t hash = fnv1_hash("bme680_bsec_state_" + to_string(this->address_));
-  this->bsec_state_ = global_preferences.make_preference<uint8_t[BSEC_MAX_STATE_BLOB_SIZE]>(hash, true);
+  this->bsec_state_ = global_preferences->make_preference<uint8_t[BSEC_MAX_STATE_BLOB_SIZE]>(hash, true);
 
   uint8_t state[BSEC_MAX_STATE_BLOB_SIZE];
   if (this->bsec_state_.load(&state)) {

--- a/components/bme680_bsec/bme680_bsec.h
+++ b/components/bme680_bsec/bme680_bsec.h
@@ -5,6 +5,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/defines.h"
 #include <map>
 
 #ifdef USE_BSEC

--- a/components/bme680_bsec/sensor.py
+++ b/components/bme680_bsec/sensor.py
@@ -54,34 +54,58 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_BME680_BSEC_ID): cv.use_id(BME680BSECComponent),
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
-            UNIT_CELSIUS, ICON_THERMOMETER, 1, DEVICE_CLASS_TEMPERATURE
+            unit_of_measurement = UNIT_CELSIUS,
+            icon = ICON_THERMOMETER,
+            accuracy_decimals = 1,
+            device_class = DEVICE_CLASS_TEMPERATURE
         ).extend(
             {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
         ),
         cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
-            UNIT_HECTOPASCAL, ICON_GAUGE, 1, DEVICE_CLASS_PRESSURE
+            unit_of_measurement = UNIT_HECTOPASCAL,
+            icon = ICON_GAUGE,
+            accuracy_decimals = 1,
+            device_class = DEVICE_CLASS_PRESSURE
         ).extend(
             {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
         ),
         cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
-            UNIT_PERCENT, ICON_WATER_PERCENT, 1, DEVICE_CLASS_HUMIDITY
+            unit_of_measurement = UNIT_PERCENT,
+            icon = ICON_WATER_PERCENT,
+            accuracy_decimals = 1,
+            device_class = DEVICE_CLASS_HUMIDITY
         ).extend(
             {cv.Optional(CONF_SAMPLE_RATE): cv.enum(SAMPLE_RATE_OPTIONS, upper=True)}
         ),
         cv.Optional(CONF_GAS_RESISTANCE): sensor.sensor_schema(
-            UNIT_OHM, ICON_GAS_CYLINDER, 0, DEVICE_CLASS_EMPTY
+            unit_of_measurement = UNIT_OHM,
+            icon = ICON_GAS_CYLINDER,
+            accuracy_decimals = 0,
+            device_class = DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_IAQ): sensor.sensor_schema(
-            UNIT_IAQ, ICON_GAUGE, 0, DEVICE_CLASS_EMPTY
+            unit_of_measurement = UNIT_IAQ,
+            icon = ICON_GAUGE,
+            accuracy_decimals = 0,
+            device_class = DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_IAQ_ACCURACY): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_ACCURACY, 0, DEVICE_CLASS_EMPTY
+            unit_of_measurement = UNIT_EMPTY,
+            icon = ICON_ACCURACY,
+            accuracy_decimals = 0,
+            device_class = DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_CO2_EQUIVALENT): sensor.sensor_schema(
-            UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+            unit_of_measurement = UNIT_PARTS_PER_MILLION,
+            icon = ICON_TEST_TUBE,
+            accuracy_decimals = 1,
+            device_class = DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_BREATH_VOC_EQUIVALENT): sensor.sensor_schema(
-            UNIT_PARTS_PER_MILLION, ICON_TEST_TUBE, 1, DEVICE_CLASS_EMPTY
+            unit_of_measurement = UNIT_PARTS_PER_MILLION,
+            icon = ICON_TEST_TUBE,
+            accuracy_decimals = 1,
+            device_class = DEVICE_CLASS_EMPTY
         ),
     }
 )


### PR DESCRIPTION
I am currently using the version 2022.7.0-dev of esphome (because 2022.6.2 is incompatible with platformio 6) but this component didn't compile because of broken dependencies. With my changes everything works fine now. Since I assume that the changes will be relevant for upcoming releases of esphome, this pull request might be of interest. Let me know.